### PR TITLE
Replace PHP short opentag

### DIFF
--- a/src/Resources/contao/templates/ce_jwplayer.html5
+++ b/src/Resources/contao/templates/ce_jwplayer.html5
@@ -21,7 +21,7 @@
 				});
 				
 				//Hide Loading Animation for none Autoplay
-				<? if(!$this->autostart): ?>
+				<?php if(!$this->autostart): ?>
 					$('#video-<?= $this->id ?>').removeClass('loading');
 				<?php endif; ?>
 				


### PR DESCRIPTION
The template threw and error for me because of a (deprecated) PHP short opentag.